### PR TITLE
Dockerfile: use image from eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:25-alpine
 
 ENV REVIEWDOG_VERSION=v0.14.0
 


### PR DESCRIPTION
openjdk images have been [deprecated](https://hub.docker.com/_/openjdk), using eclipse-temurin.